### PR TITLE
feat(display): auto-gain spectrum, vanishing peaks, volume indicator

### DIFF
--- a/common/docker/audio-visualizer/visualizer.py
+++ b/common/docker/audio-visualizer/visualizer.py
@@ -249,15 +249,19 @@ def open_alsa_capture():
 
     # Set buffer/period for low latency
     period_size = ctypes.c_ulong(HOP_SIZE)
-    libasound.snd_pcm_hw_params_set_period_size_near(
+    rc = libasound.snd_pcm_hw_params_set_period_size_near(
         handle, hw_params, ctypes.byref(period_size), None
     )
+    if rc < 0:
+        logger.warning(f"Could not set ALSA period size: error {rc}")
 
     # Explicit buffer size: 4 periods (~133ms) to prevent multi-second backlog
     buffer_size = ctypes.c_ulong(HOP_SIZE * 4)
-    libasound.snd_pcm_hw_params_set_buffer_size_near(
+    rc = libasound.snd_pcm_hw_params_set_buffer_size_near(
         handle, hw_params, ctypes.byref(buffer_size),
     )
+    if rc < 0:
+        logger.warning(f"Could not set ALSA buffer size: error {rc}")
 
     rc = libasound.snd_pcm_hw_params(handle, hw_params)
     if rc < 0:


### PR DESCRIPTION
## Summary
- **Fix 5s visualizer delay**: explicit ALSA capture buffer (133ms vs 10.9s default)
- **Auto-gain normalization**: bars reflect spectral shape regardless of volume level
- **Faster decay** (0.15 → 0.35) and **vanishing peak markers** (instant disappear after 1.5s hold)
- **Volume indicator** (Vol NN% / MUTE) displayed top-right of spectrum panel
- **Metadata service** now exposes `volume` and `muted` from Snapcast client config

## Test plan
- [x] Deployed and verified on studio Pi (snap-video)
- [ ] Play music at different volumes — bars should maintain similar heights
- [ ] Change volume via Snapcast UI — indicator updates within 2s
- [ ] Mute client — indicator shows "MUTE"

🤖 Generated with [Claude Code](https://claude.com/claude-code)