### PR TITLE
fix(install): support Bookworm cloud-init and fix path resolution

### DIFF
--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -366,7 +366,7 @@ mkdir -p "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR/public"
 
 # Copy project files (skip if source == destination, e.g. firstboot installs)
-if [[ "$(realpath "$COMMON_DIR")" != "$(realpath "$INSTALL_DIR")" ]]; then
+if [[ "$(cd "$COMMON_DIR" 2>/dev/null && pwd)" != "$(cd "$INSTALL_DIR" 2>/dev/null && pwd)" ]]; then
     cp "$COMMON_DIR/docker-compose.yml" "$INSTALL_DIR/"
     cp -r "$COMMON_DIR/docker" "$INSTALL_DIR/"
     cp "$COMMON_DIR/public/index.html" "$INSTALL_DIR/public/"

--- a/install/firstboot.sh
+++ b/install/firstboot.sh
@@ -42,7 +42,8 @@ echo "Copying files to $INSTALL_DIR ..."
 mkdir -p "$INSTALL_DIR"
 # Copy all files including dotfiles (.env.example)
 cp -r "$SNAP_BOOT/"* "$INSTALL_DIR/" 2>/dev/null || true
-cp -r "$SNAP_BOOT/".* "$INSTALL_DIR/" 2>/dev/null || true
+# .??* matches dotfiles without matching . and ..
+cp -r "$SNAP_BOOT/".??* "$INSTALL_DIR/" 2>/dev/null || true
 
 # Find config file (boot partition or install dir)
 CONFIG=""

--- a/prepare-sd.sh
+++ b/prepare-sd.sh
@@ -108,7 +108,13 @@ elif [[ -f "$USERDATA" ]]; then
         echo "user-data already patched, skipping."
     else
         echo "Patching user-data to run snapclient installer on first boot ..."
-        printf '\nruncmd:\n  - [bash, /boot/firmware/snapclient/firstboot.sh]\n' >> "$USERDATA"
+        if grep -q '^runcmd:' "$USERDATA"; then
+            # Append to existing runcmd section
+            sed -i.bak '/^runcmd:/a\  - [bash, /boot/firmware/snapclient/firstboot.sh]' "$USERDATA"
+            rm -f "${USERDATA}.bak"
+        else
+            printf '\nruncmd:\n  - [bash, /boot/firmware/snapclient/firstboot.sh]\n' >> "$USERDATA"
+        fi
         echo "  user-data patched."
     fi
 else


### PR DESCRIPTION
## Summary
- **prepare-sd.sh**: Patch cloud-init `user-data` (Bookworm+) in addition to `firstrun.sh` (Bullseye)
- **firstboot.sh**: Copy dotfiles (`.env.example`) that glob `*` misses
- **setup.sh**: Fix `COMMON_DIR` path resolution when running from `/opt/snapclient/scripts/`; skip self-copy when source == destination

## Test plan
- [x] Tested end-to-end on Pi 4 with Bookworm cloud-init
- [x] All 5 containers start successfully after firstboot
- [ ] Clean reflash test (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)