### PR TITLE
fix(snapclient): apply ALSA buffer settings for all output devices

### DIFF
--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -10,13 +10,14 @@ services:
       - /var/run/dbus:/var/run/dbus
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
       - /etc/asound.conf:/etc/asound.conf:ro
+      - ./docker/snapclient/entrypoint.sh:/entrypoint.sh:ro
     environment:
       - SNAPSERVER_HOST=${SNAPSERVER_HOST:-}
       - SNAPSERVER_PORT=${SNAPSERVER_PORT:-1704}
       - HOST_ID=${CLIENT_ID:?CLIENT_ID not set in .env}
       - SOUNDCARD=${SOUNDCARD:-default}
-      - ALSA_BUFFER_TIME=${ALSA_BUFFER_TIME:-200}
-      - ALSA_FRAGMENTS=${ALSA_FRAGMENTS:-6}
+      - ALSA_BUFFER_TIME=${ALSA_BUFFER_TIME:-150}
+      - ALSA_FRAGMENTS=${ALSA_FRAGMENTS:-4}
     privileged: true
 
   metadata-service:

--- a/common/docker/snapclient/entrypoint.sh
+++ b/common/docker/snapclient/entrypoint.sh
@@ -5,24 +5,24 @@ set -e
 SNAPSERVER_PORT="${SNAPSERVER_PORT:-1704}"
 HOST_ID="${HOST_ID:-snapclient}"
 SOUNDCARD="${SOUNDCARD:-default}"
-ALSA_BUFFER_TIME="${ALSA_BUFFER_TIME:-200}"
-ALSA_FRAGMENTS="${ALSA_FRAGMENTS:-6}"
+ALSA_BUFFER_TIME="${ALSA_BUFFER_TIME:-150}"
+ALSA_FRAGMENTS="${ALSA_FRAGMENTS:-4}"
 
 # Validate numeric values and enforce sane bounds
 case "${ALSA_BUFFER_TIME}" in
-    ''|*[!0-9]*) echo "Invalid ALSA_BUFFER_TIME, using default 200"; ALSA_BUFFER_TIME=200 ;;
+    ''|*[!0-9]*) echo "Invalid ALSA_BUFFER_TIME, using default 150"; ALSA_BUFFER_TIME=150 ;;
 esac
 if [ "${ALSA_BUFFER_TIME}" -lt 50 ] || [ "${ALSA_BUFFER_TIME}" -gt 2000 ]; then
-    echo "ALSA_BUFFER_TIME out of range (50-2000), using default 200"
-    ALSA_BUFFER_TIME=200
+    echo "ALSA_BUFFER_TIME out of range (50-2000), using default 150"
+    ALSA_BUFFER_TIME=150
 fi
 
 case "${ALSA_FRAGMENTS}" in
-    ''|*[!0-9]*) echo "Invalid ALSA_FRAGMENTS, using default 6"; ALSA_FRAGMENTS=6 ;;
+    ''|*[!0-9]*) echo "Invalid ALSA_FRAGMENTS, using default 4"; ALSA_FRAGMENTS=4 ;;
 esac
 if [ "${ALSA_FRAGMENTS}" -lt 2 ] || [ "${ALSA_FRAGMENTS}" -gt 16 ]; then
-    echo "ALSA_FRAGMENTS out of range (2-16), using default 6"
-    ALSA_FRAGMENTS=6
+    echo "ALSA_FRAGMENTS out of range (2-16), using default 4"
+    ALSA_FRAGMENTS=4
 fi
 
 echo "Starting snapclient..."
@@ -36,13 +36,9 @@ echo "  Soundcard: ${SOUNDCARD}"
 # Build command - only add --host if explicitly set
 CMD="/usr/bin/snapclient --hostID ${HOST_ID} --soundcard ${SOUNDCARD}"
 
-# Only add ALSA buffer tuning for ALSA devices (hw: or plughw:)
-case "${SOUNDCARD}" in
-    hw:*|plughw:*)
-        echo "  ALSA buffer: ${ALSA_BUFFER_TIME}ms, ${ALSA_FRAGMENTS} fragments"
-        CMD="${CMD} --player alsa:buffer_time=${ALSA_BUFFER_TIME}:fragments=${ALSA_FRAGMENTS}"
-        ;;
-esac
+# Apply ALSA buffer tuning for all ALSA output to reduce underruns
+echo "  ALSA buffer: ${ALSA_BUFFER_TIME}ms, ${ALSA_FRAGMENTS} fragments"
+CMD="${CMD} --player alsa:buffer_time=${ALSA_BUFFER_TIME}:fragments=${ALSA_FRAGMENTS}"
 
 if [ -n "${SNAPSERVER_HOST}" ]; then
     CMD="${CMD} --host ${SNAPSERVER_HOST} --port ${SNAPSERVER_PORT}"


### PR DESCRIPTION
## Summary
- Apply ALSA buffer tuning for ALL ALSA output devices, not just `hw:*` or `plughw:*`
- Previously, using `default` soundcard caused 80ms buffer → underruns during playback
- Tune defaults to 150ms buffer, 4 fragments (balanced latency vs stability)
- Add volume mount for entrypoint.sh to allow local overrides without rebuilding

## Problem
Snapclient logs showed ALSA buffer underruns:
```
[Info] (Alsa) Using default buffer_time: 80 ms, default fragments: 4
[Info] (Stream) Exception: Not enough frames available, requested frames: 960, available: 237
[Error] (Alsa) XRUN while waiting for PCM: Broken pipe
```

## Solution
Apply `--player alsa:buffer_time=150:fragments=4` for all ALSA output, not conditionally.

## Test plan
- [x] Deploy to snap-video
- [x] Verify buffer settings applied: `buffer time: 150000 us`
- [x] Play music, check for XRUN/underrun errors
- [x] Confirm clean logs during playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)