### PR TITLE
fix(fb-display): simplify clock and eliminate flicker

### DIFF
--- a/common/docker/fb-display/fb_display.py
+++ b/common/docker/fb-display/fb_display.py
@@ -822,7 +822,6 @@ def render_clock() -> tuple[np.ndarray, int, int] | None:
 
     # Check cache (changes every second)
     if display_str == _clock_cache["time_str"] and _clock_cache["fb"] is not None:
-        _clock_cache["dirty"] = False
         return _clock_cache["fb"], _clock_cache["width"], _clock_cache["height"]
 
     # Small font — roughly half the bottom bar height
@@ -871,7 +870,6 @@ def render_progress_overlay() -> tuple[np.ndarray, int, int, int, int] | None:
     if (elapsed == _progress_cache["elapsed"] and
             duration == _progress_cache["duration"] and
             _progress_cache["fb"] is not None):
-        _progress_cache["dirty"] = False
         return (
             _progress_cache["fb"],
             _progress_cache["width"],


### PR DESCRIPTION
## Summary

- **Clock simplified**: replaced the retro-styled decorated clock (double borders, text shadow, corner dots, bold cyan font) with a small muted plain-text clock at half the font size
- **Flicker eliminated**: added a `dirty` flag to both `_clock_cache` and `_progress_cache` so `render_loop` only writes these regions to the framebuffer when content actually changes (~1x/sec instead of 5-20x/sec on every frame)
- After `write_full_frame` (metadata change), both dirty flags are forced `True` since the base frame overwrites the clock/progress regions

## Test plan

- [ ] Verify clock displays as small muted text centered in bottom bar
- [ ] Verify no visible flicker on the clock or progress bar regions
- [ ] Verify clock still updates every second
- [ ] Verify progress bar still updates during file playback
- [ ] Verify clock/progress redraw correctly after metadata change (track skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)