### PR TITLE
fix: address codebase review findings (4 MEDIUM issues)

### DIFF
--- a/common/docker/fb-display/fb_display.py
+++ b/common/docker/fb-display/fb_display.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 # Display configuration
 METADATA_HOST = os.environ.get("METADATA_HOST", "") or "localhost"
 METADATA_WS_PORT = int(os.environ.get("METADATA_WS_PORT", "8082"))
-METADATA_HTTP_PORT = int(os.environ.get("METADATA_HTTP_PORT", "8080"))
+METADATA_HTTP_PORT = int(os.environ.get("METADATA_HTTP_PORT", "8083"))
 CLIENT_ID = os.environ.get("CLIENT_ID", "")
 SPECTRUM_WS_PORT = int(os.environ.get("VISUALIZER_WS_PORT", "8081"))
 FB_DEVICE = "/dev/fb0"

--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -997,7 +997,7 @@ declare -A env_vars=(
     # Empty = mDNS autodiscovery (same as SNAPSERVER_HOST)
     ["METADATA_HOST"]="${snapserver_ip}"
     ["METADATA_WS_PORT"]="8082"
-    ["METADATA_HTTP_PORT"]="8080"
+    ["METADATA_HTTP_PORT"]="8083"
     # Resource limits (auto-detected)
     ["SNAPCLIENT_MEM_LIMIT"]="$SNAPCLIENT_MEM_LIMIT"
     ["SNAPCLIENT_MEM_RESERVE"]="$SNAPCLIENT_MEM_RESERVE"


### PR DESCRIPTION
## Summary
- **Thread safety**: Acquire `_band_lock` in `_handle_spectrum_error` to prevent race condition with render thread
- **Render loop resilience**: Wrap `render_loop` body in try/except so errors log and recover instead of silently killing the display
- **Port consistency**: Align all `METADATA_HTTP_PORT` defaults to `8083` (server's HTTP artwork port) across docker-compose.yml, fb_display.py, and setup.sh
- **Broadcast race fix**: Use single `ws_clients` snapshot in `broadcast_metadata` to prevent client/result mismatch when clients disconnect between two `.copy()` calls

## Files changed
| File | Change |
|------|--------|
| `common/docker/fb-display/fb_display.py` | Lock in error handler + try/except in render loop + port default 8083 |
| `common/docker/metadata-service/metadata-service.py` | Single snapshot in broadcast |
| `common/scripts/setup.sh` | Port default consistent at 8083 |

## Test plan
- [ ] Deploy to snapvideo, verify display renders without issues
- [ ] Kill metadata-service WS mid-render — display should log error and recover (not freeze)
- [ ] Fresh install: verify `.env` has `METADATA_HTTP_PORT=8083`
- [ ] Play a track with album art — artwork should load correctly via server:8083

🤖 Generated with [Claude Code](https://claude.com/claude-code)