### PR TITLE
fix: revert RGB565 LUT — bitwise is faster on ARM

### DIFF
--- a/common/docker/fb-display/fb_display.py
+++ b/common/docker/fb-display/fb_display.py
@@ -450,12 +450,6 @@ def compute_layout() -> dict:
     }
 
 
-# Pre-computed RGB565 lookup tables — integer indexing avoids per-pixel astype + bitwise
-_R_LUT = (np.arange(256, dtype=np.uint16) & 0xF8) << 8
-_G_LUT = (np.arange(256, dtype=np.uint16) & 0xFC) << 3
-_B_LUT = np.arange(256, dtype=np.uint16) >> 3
-
-
 def _rgb_to_fb_native(rgb_array: np.ndarray) -> np.ndarray:
     """Convert RGB numpy array to native FB pixel format array.
 
@@ -463,9 +457,9 @@ def _rgb_to_fb_native(rgb_array: np.ndarray) -> np.ndarray:
     """
     if fb_bpp == 16:
         return (
-            _R_LUT[rgb_array[:, :, 0]]
-            | _G_LUT[rgb_array[:, :, 1]]
-            | _B_LUT[rgb_array[:, :, 2]]
+            (rgb_array[:, :, 0].astype(np.uint16) & 0xF8) << 8
+            | (rgb_array[:, :, 1].astype(np.uint16) & 0xFC) << 3
+            | rgb_array[:, :, 2].astype(np.uint16) >> 3
         )
     else:
         h, w = rgb_array.shape[:2]


### PR DESCRIPTION
## Summary
- Reverts RGB565 lookup table conversion introduced in PR #60
- Real Pi benchmarks (Cortex-A72) showed fancy indexing LUTs are **35-75% slower** than direct `astype(uint16)` + bitwise ops at all region sizes
- Removes `_R_LUT`/`_G_LUT`/`_B_LUT` globals

## Benchmark results (snapvideo, 1920x1080 16bpp)

| Region | LUT | Bitwise | Winner |
|--------|-----|---------|--------|
| clock 200x30 | 0.190ms | 0.109ms | Bitwise |
| progress 800x20 | 0.467ms | 0.181ms | Bitwise |
| full 1920x1080 | 66.9ms | 47.5ms | Bitwise |

## Test plan
- [x] Syntax check passes
- [ ] Deploy to snapvideo, verify display renders correctly
- [ ] `docker stats` confirms CPU improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)