### PR TITLE
feat: show LAN IP and snapserver in bottom bar

### DIFF
--- a/common/docker/fb-display/fb_display.py
+++ b/common/docker/fb-display/fb_display.py
@@ -44,11 +44,9 @@ TARGET_FPS = 20
 def _get_lan_ip() -> str:
     """Get LAN IP via UDP socket (no traffic sent)."""
     try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect(("8.8.8.8", 80))
-        ip = s.getsockname()[0]
-        s.close()
-        return ip
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
     except Exception:
         return "?.?.?.?"
 

--- a/tests/test_fb_display.py
+++ b/tests/test_fb_display.py
@@ -429,6 +429,25 @@ class TestComputeLayout:
         assert L["art_size"] > 0
 
 
+class TestGetLanIp:
+    """Test LAN IP detection."""
+
+    def test_returns_ip_string(self):
+        ip = fb_display._get_lan_ip()
+        parts = ip.split(".")
+        assert len(parts) == 4
+        for part in parts:
+            assert part.isdigit()
+            assert 0 <= int(part) <= 255
+
+    def test_fallback_on_socket_error(self, monkeypatch):
+        import socket
+        def _raise(*a, **kw):
+            raise OSError("no network")
+        monkeypatch.setattr(socket, "socket", _raise)
+        assert fb_display._get_lan_ip() == "?.?.?.?"
+
+
 class TestIsSpectrumActive:
     """Test spectrum activity detection."""
 


### PR DESCRIPTION
## Summary

- Add status line below the clock in the bottom bar: `192.168.63.5 → snapvideo.local`
- LAN IP resolved once at startup via UDP socket (no traffic sent)
- Snapserver address from existing `METADATA_HOST` env var
- Rendered into base frame (static) — zero per-frame cost

Helps identify which client you're looking at and which server it connects to, useful for multi-client setups and debugging.

## Test plan

- [x] 94 unit tests pass (`uvx --with numpy --with pillow --with websockets --with requests pytest tests/ -v`)
- [ ] Deploy to snapvideo: `rsync fb_display.py`, restart fb-display — verify status line visible
- [ ] Deploy to snapdigi: different LAN IP shown, same snapserver address

🤖 Generated with [Claude Code](https://claude.com/claude-code)