### PR TITLE
fix: install avahi-utils for mDNS discovery

### DIFF
--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -548,11 +548,11 @@ log_progress "apt-get update"
 start_progress_animation 1 0 12  # Animate during apt-get
 
 # Base packages (always needed)
-BASE_PACKAGES="ca-certificates curl gnupg alsa-utils avahi-daemon git"
+BASE_PACKAGES="ca-certificates curl gnupg alsa-utils avahi-daemon avahi-utils git"
 
 apt-get update
 log_progress "apt-get install: ca-certificates curl gnupg..."
-log_progress "apt-get install: alsa-utils avahi-daemon git..."
+log_progress "apt-get install: alsa-utils avahi-daemon avahi-utils git..."
 # shellcheck disable=SC2086
 apt-get install -y $BASE_PACKAGES
 log_progress "System packages installed"


### PR DESCRIPTION
## Summary

- Add `avahi-utils` to `BASE_PACKAGES` in `setup.sh`
- Provides `avahi-browse` which is required by the mDNS discovery block (line 920) that resolves `SNAPSERVER_HOST` when empty

## Root cause

`setup.sh` installed `avahi-daemon` but not `avahi-utils`. When `SNAPSERVER_HOST` was empty, the discovery block tried `avahi-browse` which didn't exist, silently failed, and wrote an empty `SNAPSERVER_HOST` to `.env`. This caused fb-display to fall back to `localhost` for metadata — broken on client-only hosts like snapdigi where no metadata service runs locally.

## Test plan

- [ ] Fresh install: `avahi-browse` available after setup, `SNAPSERVER_HOST` populated via mDNS
- [ ] Re-run `setup.sh` on snapdigi: `avahi-utils` installed, discovery succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)