### PR TITLE
fix: pull Docker images once, after storage driver switch

### DIFF
--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -92,11 +92,11 @@ PROGRESS_ANIM_PID=""
 
 STEP_NAMES=("System dependencies" "Docker CE" "Audio HAT config"
             "ALSA loopback" "Boot settings" "Docker environment"
-            "Security hardening" "Systemd service" "Pulling images"
-            "Read-only filesystem")
+            "Security hardening" "Systemd service" "Read-only filesystem"
+            "Pulling images")
 
 # Weights reflect actual duration (Pull=40%, Docker=33%, Deps=12%, RO=5%, rest=10%)
-STEP_WEIGHTS=(12 33 2 2 2 2 2 3 37 5)
+STEP_WEIGHTS=(12 33 2 2 2 2 2 3 5 37)
 
 # Log file: use parent's if PROGRESS_MANAGED, otherwise our own
 if [[ -n "$PROGRESS_MANAGED" ]]; then


### PR DESCRIPTION
## Summary
Harden setup.sh against multiple failure modes discovered during fresh installs.

### Fixes
- **Single image pull**: Move read-only/fuse-overlayfs config before `docker compose pull` — images were pulled twice (once, wiped by storage driver switch, pulled again)
- **Guard file installs**: `ro-mode.sh` and `daemon.json` installs now check file existence (same pattern as discover-server.sh fix in #71)
- **Timeout on mDNS discovery**: `avahi-browse` now has 10s timeout to prevent hangs if avahi-daemon is slow
- **Preserve SNAPSERVER_HOST**: Don't overwrite existing value with empty string when mDNS discovery fails on re-run
- **Persist SSH host keys**: Save host keys before enabling read-only FS and restore on boot via systemd service — prevents "REMOTE HOST IDENTIFICATION HAS CHANGED" on every reboot
- **Deduplicate CMDLINE detection**: Was resolved 3 times identically, now set once
- **Fix duplicate Step 10 labels**
- **Fix shellcheck warning**: Add directive for non-constant source

## Test plan
- [x] `bash -n` syntax check passes
- [x] `shellcheck --severity=warning` passes
- [x] Pre-push hooks pass
- [ ] Deploy to snapdigi (currently unreachable, will deploy when back online)

🤖 Generated with [Claude Code](https://claude.com/claude-code)