### PR TITLE
docs: update changelog for v0.2.2 and fix firstboot config precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Setup Fails on Missing discover-server.sh** ([#71](https://github.com/lollonet/rpi-snapclient-usb/pull/71)) - Guard file install with existence check; use systemd `ExecStartPre=-` prefix so containers start even without the discovery script
+- **Double Docker Image Pull** ([#72](https://github.com/lollonet/rpi-snapclient-usb/pull/72)) - Move read-only/fuse-overlayfs config before `docker compose pull` so images are only downloaded once
+- **SSH Host Keys Lost on Read-Only Reboot** ([#72](https://github.com/lollonet/rpi-snapclient-usb/pull/72)) - Persist SSH host keys before enabling overlayfs via systemd restore service; prevents "REMOTE HOST IDENTIFICATION HAS CHANGED" on every reboot
+- **avahi-browse Hangs During Setup** ([#72](https://github.com/lollonet/rpi-snapclient-usb/pull/72)) - Added 10s timeout to mDNS discovery to prevent setup from hanging if avahi-daemon is slow to start
+- **SNAPSERVER_HOST Cleared on Re-run** ([#72](https://github.com/lollonet/rpi-snapclient-usb/pull/72)) - Don't overwrite existing value with empty string when mDNS discovery fails during setup re-run
+- **Missing File Guards** ([#72](https://github.com/lollonet/rpi-snapclient-usb/pull/72)) - Guard `ro-mode.sh` and `daemon.json` installs with existence checks (same pattern as discover-server.sh)
+
+## [0.2.2] - 2026-03-07
+
+### Added
+- **LAN IP and Snapserver in Display** ([#68](https://github.com/lollonet/rpi-snapclient-usb/pull/68)) - Status line in bottom bar shows `192.168.63.5 → snapvideo.local` for easy identification of client and server
+- **mDNS Auto-Discovery for Server Failover** ([#70](https://github.com/lollonet/rpi-snapclient-usb/pull/70)) - fb-display discovers alternative snapservers via `_snapcast._tcp` mDNS after 3 failed reconnects; switches server and updates status line automatically
+
+### Fixed
+- **Missing avahi-utils** ([#69](https://github.com/lollonet/rpi-snapclient-usb/pull/69)) - Added `avahi-utils` to setup.sh `BASE_PACKAGES` so `avahi-browse` is available for mDNS discovery
+
 ## [0.2.1] - 2026-03-05
 
 ### Added

--- a/install/firstboot.sh
+++ b/install/firstboot.sh
@@ -37,6 +37,13 @@ log_and_tty "========================================="
 log_and_tty "Snapclient Auto-Install"
 log_and_tty "========================================="
 
+# Find config file BEFORE copying (preserve boot partition config priority)
+CONFIG=""
+if [ -f "$SNAP_BOOT/snapclient.conf" ]; then
+    CONFIG="$SNAP_BOOT/snapclient.conf"
+    log_and_tty "Using custom config from boot partition"
+fi
+
 # Copy project files from boot partition
 log_and_tty "Copying files to $INSTALL_DIR ..."
 mkdir -p "$INSTALL_DIR"
@@ -45,12 +52,10 @@ cp -r "$SNAP_BOOT/"* "$INSTALL_DIR/"
 # .??* matches dotfiles without matching . and ..
 cp -r "$SNAP_BOOT/".??* "$INSTALL_DIR/" 2>/dev/null || true  # dotfiles may not exist
 
-# Find config file (boot partition or install dir)
-CONFIG=""
-if [ -f "$SNAP_BOOT/snapclient.conf" ]; then
-    CONFIG="$SNAP_BOOT/snapclient.conf"
-elif [ -f "$INSTALL_DIR/snapclient.conf" ]; then
+# Fallback to install dir config if none was found on boot partition
+if [ -z "$CONFIG" ] && [ -f "$INSTALL_DIR/snapclient.conf" ]; then
     CONFIG="$INSTALL_DIR/snapclient.conf"
+    log_and_tty "Using default config from install directory"
 fi
 
 # Run setup in auto mode (all output goes to log only; progress() writes to tty1 directly)


### PR DESCRIPTION
## Summary
- Add v0.2.2 section to CHANGELOG.md (PRs #68-#70: status line, mDNS failover, avahi-utils)
- Add [Unreleased] section (PRs #71-#72: setup hardening fixes)
- Fix config precedence in `firstboot.sh`: read boot partition config **before** copying files so user customizations take priority

## Test plan
- [x] Shellcheck passes
- [x] Changelog follows Keep a Changelog format

🤖 Generated with [Claude Code](https://claude.com/claude-code)