### PR TITLE
fix: show both client and server versions in status line

### DIFF
--- a/common/docker/fb-display/fb_display.py
+++ b/common/docker/fb-display/fb_display.py
@@ -854,6 +854,8 @@ def render_base_frame() -> Image.Image:
             bg.paste(brand_resized, (brand_x, brand_y), brand_resized)
 
     # Bottom bar: status line (LAN IP → server  client_ver  /  server_ver)
+    # APP_VERSION already carries its own "v" prefix (from git describe, e.g. "v0.2.4").
+    # srv_ver is prefixed inline as "srv X.Y.Z" — asymmetry is intentional.
     srv_ver = server_info.get("server_version", "")
     ver_parts = []
     if APP_VERSION:

--- a/tests/test_fb_display.py
+++ b/tests/test_fb_display.py
@@ -557,6 +557,45 @@ class TestHandleMetadataMessage:
         assert fb_display.server_info == {}
 
 
+class TestVersionSuffix:
+    """Test ver_suffix formatting logic from render_base_frame (4 combinations)."""
+
+    def _compute_suffix(self, app_version: str, srv_ver: str) -> str:
+        """Mirror the ver_suffix logic from render_base_frame."""
+        ver_parts = []
+        if app_version:
+            ver_parts.append(app_version)
+        if srv_ver and srv_ver != "unknown":
+            ver_parts.append(f"srv {srv_ver}")
+        return "  •  " + "  /  ".join(ver_parts) if ver_parts else ""
+
+    def test_both_versions(self):
+        suffix = self._compute_suffix("v0.2.4", "0.3.7")
+        assert suffix == "  •  v0.2.4  /  srv 0.3.7"
+
+    def test_client_only(self):
+        suffix = self._compute_suffix("v0.2.4", "")
+        assert suffix == "  •  v0.2.4"
+
+    def test_server_only(self):
+        suffix = self._compute_suffix("", "0.3.7")
+        assert suffix == "  •  srv 0.3.7"
+
+    def test_neither(self):
+        suffix = self._compute_suffix("", "")
+        assert suffix == ""
+
+    def test_server_unknown_treated_as_missing(self):
+        suffix = self._compute_suffix("v0.2.4", "unknown")
+        assert suffix == "  •  v0.2.4"
+
+    def test_status_text_format(self):
+        """Full status_text assembles correctly."""
+        suffix = self._compute_suffix("v0.2.4", "0.3.7")
+        status = f"192.168.1.1  →  snapvideo{suffix}"
+        assert status == "192.168.1.1  →  snapvideo  •  v0.2.4  /  srv 0.3.7"
+
+
 class TestIsSpectrumActive:
     """Test spectrum activity detection."""
 


### PR DESCRIPTION
## Summary
- Previous logic showed server version **or** client version (fallback). Now shows **both**
- Format: `192.168.63.104 → snapvideo  •  v0.2.4  /  srv 0.3.7`
- Gracefully handles missing versions: shows only what's available

## Test plan
- [ ] Verify display shows both `v0.2.4` (client) and `srv 0.3.7` (server) simultaneously
- [ ] Verify with `APP_VERSION` unset — shows only server version
- [ ] Verify before `server_info` WS message arrives — shows only client version

🤖 Generated with [Claude Code](https://claude.com/claude-code)