### PR TITLE
fix(setup): read APP_VERSION from VERSION file baked by prepare-sd.sh

### DIFF
--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -1064,7 +1064,7 @@ declare -A env_vars=(
     ["CONNECTION_TYPE"]="$CONNECTION_TYPE"
     # Version tag (for display) — prefer VERSION file baked by prepare-sd.sh,
     # fall back to git describe (dev clones), then short SHA, then "dev".
-    ["APP_VERSION"]="$(cat "$PROJECT_DIR/VERSION" 2>/dev/null || git -C "$PROJECT_DIR" describe --tags --abbrev=0 2>/dev/null || git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo "dev")"
+    ["APP_VERSION"]="$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || git -C "$PROJECT_DIR" describe --tags --abbrev=0 2>/dev/null || git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo "dev")"
 )
 
 for key in "${!env_vars[@]}"; do


### PR DESCRIPTION
## Problem

`APP_VERSION` was always `dev` on SD-card installs because `setup.sh` resolved it via `git describe`, which fails outside a git repo (devices don't have a cloned repo).

## Fix

**`prepare-sd.sh`** (runs on host, which IS a git repo): write the client version to `$BOOT/snapmulti/client/VERSION` after copying files.

**`setup.sh`**: check `$PROJECT_DIR/VERSION` first before trying git.

Fall-back chain: `VERSION` file → `git describe` → `git short SHA` → `"dev"`

The `VERSION` file flows: `prepare-sd.sh` → boot partition → `firstboot.sh` copies to `/opt/snapclient/VERSION` → `setup.sh` reads it.

Note: the matching `prepare-sd.sh` change is in the server repo (snapMULTI).

## Test plan
- [ ] Flash SD card with `prepare-sd.sh` (client or both mode)
- [ ] `cat $BOOT/snapmulti/client/VERSION` → shows `v0.2.x`
- [ ] After first-boot install: `grep APP_VERSION /opt/snapclient/.env` → `v0.2.x` (not `dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)