### PR TITLE
fix(fb-display): skip redraw when server_info content unchanged

### DIFF
--- a/common/docker/fb-display/fb_display.py
+++ b/common/docker/fb-display/fb_display.py
@@ -1247,10 +1247,11 @@ async def _handle_metadata_message(message: str) -> None:
     try:
         data = json.loads(message)
 
-        # Server info broadcast — update global and trigger base frame redraw
+        # Server info broadcast — only redraw if content actually changed
         if data.get("type") == "server_info":
-            server_info = data
-            metadata_version += 1
+            if data != server_info:
+                server_info = data
+                metadata_version += 1
             return
 
         # Sync playback clock for progress bar


### PR DESCRIPTION
## Summary

- `server_info` WebSocket messages arrive every ~20 s
- Previous code always incremented `metadata_version` → full base frame redraw every ~20 s
- Fix: only redraw when the `server_info` dict actually differs from the previous one

## Root cause

Diagnosed by sniffing the metadata WebSocket from inside the fb-display container:

```
 0.0s [metadata]    changed=[] (stable)
 0.0s [server_info] changed=[all keys vs prev metadata dict]   ← triggers version++
20.2s [metadata]    changed=[]
20.2s [server_info] changed=[all keys vs prev metadata dict]   ← triggers version++ again
```

`server_info` fires every ~20 s with identical content (`server_version`, `connected_clients`, `active_streams` all unchanged), but the unconditional `metadata_version += 1` caused a visible screen redraw each time.

## Test plan
- [ ] Deploy to snapdigi, observe `docker logs fb-display` — "Base frame updated" should only appear on actual track changes or server version changes, not every 20 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)