### PR TITLE
feat(ci): use GitHub Environments for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,11 @@ name: Deploy to Device
 
 on:
   workflow_call:
-    secrets:
-      HOST:
+    inputs:
+      environment_name:
+        type: string
         required: true
+    secrets:
       USER:
         required: true
       SSH_KEY:
@@ -17,6 +19,10 @@ on:
 jobs:
   deploy:
     runs-on: [self-hosted, linux, x64]
+    environment: ${{ inputs.environment_name }}
+    concurrency:
+      group: deploy-${{ inputs.environment_name }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -158,8 +158,9 @@ jobs:
     needs: [build-snapclient, build-visualizer, build-fb-display]
     if: startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/deploy.yml
+    with:
+      environment_name: snapvideo
     secrets:
-      HOST:               ${{ secrets.HOST_SNAPVIDEO }}
       USER:               ${{ secrets.USER }}
       SSH_KEY:            ${{ secrets.SSH_KEY }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -169,8 +170,9 @@ jobs:
     needs: [build-snapclient, build-visualizer, build-fb-display]
     if: startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/deploy.yml
+    with:
+      environment_name: snapdigi
     secrets:
-      HOST:               ${{ secrets.HOST_SNAPDIGI }}
       USER:               ${{ secrets.USER }}
       SSH_KEY:            ${{ secrets.SSH_KEY }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary
- `deploy.yml`: accepts `environment_name` string input; sets `environment:` and `concurrency:` on the deploy job
- `build-push.yml`: passes `environment_name: snapvideo`; removes `HOST` from secrets (now from environment)

## Why
`HOST` secret moved from repository-level to GitHub Environment scope, so each environment (`snapvideo`) has its own `HOST` without needing per-device secret names. Concurrency group queues deploys rather than canceling in-progress ones.

## Prerequisites
In repo Settings → Environments → `snapvideo` → Secrets: add `HOST` pointing to the server's IP/hostname.
Remove the old `HOST` repository secret once confirmed working.

## Test plan
- [ ] Push a `v*` tag and verify deploy job uses `snapvideo` environment
- [ ] Check deployment protection rules fire (if configured)
- [ ] Confirm `HOST` resolves from environment secret
- [ ] Trigger two deploys back-to-back; second should queue, not cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)