### PR TITLE
fix(setup): add I2C bus scan for HATs without EEPROM

### DIFF
--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -434,13 +434,15 @@ detect_hat() {
     # I2C bus scan: detect DAC chips by address, works even without overlay loaded.
     # Many cheap HATs (InnoMaker, Waveshare, some Allo) ship without an EEPROM, so
     # the overlay is never loaded and aplay -l never shows the card. Raw I2C probing
-    # identifies the chip regardless. Loads i2c-dev transiently; no side effects.
+    # identifies the chip regardless. modprobe i2c-dev persists until reboot.
     # Known addresses:
     #   0x4C-0x4F  PCM5122 (InnoMaker HiFi DAC, IQaudio DAC+, Allo Boss, JustBoom DAC, …)
+    #              NOTE: shared with TMP112, ADS1x1x, PCA9685 and other non-DAC chips.
+    #              Safe on a bare Pi + DAC HAT; may false-positive on mixed I2C buses.
     #   0x1A       WM8960  (Waveshare WM8960)
     #   0x3A       WM8804  (HiFiBerry Digi, JustBoom Digi, Allo DigiOne — no EEPROM variants)
     if ! command -v i2cdetect &>/dev/null; then
-        apt-get install -y -q i2c-tools 2>/dev/null || true
+        apt-get install -y -q i2c-tools || true
     fi
     modprobe i2c-dev 2>/dev/null || true
     if command -v i2cdetect &>/dev/null; then


### PR DESCRIPTION
## Summary

- HATs from InnoMaker, Waveshare, and some Allo boards ship without an EEPROM — setup.sh always fell through to `usb-audio` for these
- Root cause: both existing detection paths (EEPROM + ALSA card names) require the overlay to be loaded first — chicken-and-egg
- Add step 3: raw I2C bus scan using `i2cdetect`, which works before any overlay is loaded; installs `i2c-tools` transiently if needed

**Detected addresses:**
| Address | Chip | → HAT config |
|---------|------|-------------|
| 0x4C–0x4F | PCM5122 | `hifiberry-dac` (InnoMaker HiFi DAC, Allo Boss, JustBoom DAC…) |
| 0x1A | WM8960 | `waveshare-wm8960` |
| 0x3A | WM8804 | `hifiberry-digi` (DigiOne, Digi HATs without EEPROM) |

## Test plan

- [ ] Flash Pi with InnoMaker HiFi DAC HAT (no EEPROM) → run `setup.sh --auto` → verify `hifiberry-dac` detected
- [ ] Verify i2c-tools installed when missing, skipped when already present
- [ ] Verify USB audio still detected when no I2C DAC found
- [ ] Verify shellcheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)