### PR TITLE
fix(setup): raise fb-display memory limit in low profile to 192M

### DIFF
--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -970,8 +970,8 @@ set_resource_limits() {
             VISUALIZER_MEM_LIMIT="128M"
             VISUALIZER_MEM_RESERVE="64M"
             VISUALIZER_CPU_LIMIT="0.5"
-            FBDISPLAY_MEM_LIMIT="128M"
-            FBDISPLAY_MEM_RESERVE="64M"
+            FBDISPLAY_MEM_LIMIT="192M"
+            FBDISPLAY_MEM_RESERVE="96M"
             FBDISPLAY_CPU_LIMIT="0.5"
             ;;
         medium)


### PR DESCRIPTION
## Summary

- fb-display uses ~120 MiB at runtime (observed on Pi 3B+ monia-client and Pi 4 snapvideo)
- The `low` profile limit of 128M left only 8M headroom — OOM kill risk
- Raised to 192M / 96M reserve to match actual usage

## Test plan
- [ ] Verify fb-display runs without OOM on Pi 3B+ after re-running setup.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)