### PR TITLE
fix(setup): enable i2c_arm at runtime before HAT I2C scan

### DIFF
--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -444,6 +444,10 @@ detect_hat() {
     if ! command -v i2cdetect &>/dev/null; then
         apt-get install -y -q i2c-tools || true
     fi
+    # Enable i2c_arm at runtime in case dtparam=i2c_arm=on is not yet in config.txt
+    # (e.g. on first boot before setup.sh has written the overlay). dtparam applies
+    # the param immediately without reboot; modprobe i2c-dev exposes /dev/i2c-*.
+    dtparam i2c_arm=on 2>/dev/null || true
     modprobe i2c-dev 2>/dev/null || true
     if command -v i2cdetect &>/dev/null; then
         local bus addr result=""


### PR DESCRIPTION
## Summary

- On first boot, `dtparam=i2c_arm=on` is not yet in `config.txt` — it only gets written by setup.sh *after* HAT detection
- Without it, `/dev/i2c-1` is absent even after `modprobe i2c-dev`, so the PCM5122 scan returns nothing and falls back to `usb-audio`
- This caused setup to fail on monia-client (Pi 3B+ + InnoMaker HiFi DAC) with `ERROR: HAT configuration file not found`
- Fix: call `dtparam i2c_arm=on` before scanning — applies at runtime, no reboot needed

## Test plan
- [ ] Fresh flash Pi with InnoMaker HiFi DAC HAT → firstboot auto-detects `hifiberry-dac` without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)