### PR TITLE
feat(snapclient): upgrade to v0.35.0 from upstream badaix/snapcast

### DIFF
--- a/common/docker/snapclient/Dockerfile
+++ b/common/docker/snapclient/Dockerfile
@@ -17,14 +17,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone and build snapclient from santcasp fork (matches server)
-# SANTCASP_SHA busts the Docker cache when santcasp has new commits
-ARG SANTCASP_SHA=latest
+# Clone and build snapclient from upstream badaix/snapcast
+# SNAPCAST_TAG busts the Docker cache when new version is released
+ARG SNAPCAST_TAG=v0.35.0
 WORKDIR /build
-RUN echo "santcasp SHA: $SANTCASP_SHA" && \
-    git clone --depth 1 --branch develop https://github.com/lollonet/santcasp.git snapcast && \
-    sed -i 's/VERSION [0-9.]*-santcasp/VERSION 0.34.1/' snapcast/CMakeLists.txt && \
-    grep -q 'VERSION 0.34.1' snapcast/CMakeLists.txt
+RUN echo "snapcast tag: $SNAPCAST_TAG" && \
+    git clone --depth 1 --branch $SNAPCAST_TAG https://github.com/badaix/snapcast.git snapcast
 
 WORKDIR /build/snapcast
 RUN cmake -S . -B build \


### PR DESCRIPTION
## Summary
- Upgrade snapclient from 0.34.1 → 0.35.0
- Switch from `lollonet/santcasp` fork to upstream `badaix/snapcast`
- Use tagged releases instead of develop branch for better version control

## Changes
- Repo: `lollonet/santcasp` (develop) → `badaix/snapcast` (tagged)
- Build arg: `SANTCASP_SHA` → `SNAPCAST_TAG=v0.35.0`
- Removed version sed patching (upstream is already correct)

## Test plan
- [x] Docker image builds successfully
- [x] Version confirmed: `snapclient v0.35.0`
- [x] Deploy to device and verify server connection
- [x] Verify audio playback works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)