### PR TITLE
ci: expect 16 HAT configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Validate HAT config count
         run: |
           count=$(ls -1 common/audio-hats/*.conf | wc -l)
-          if [ "$count" -ne 15 ]; then
-            echo "Expected 15 HAT configs, found $count"
+          if [ "$count" -ne 16 ]; then
+            echo "Expected 16 HAT configs, found $count"
             exit 1
           fi
-          echo "All 15 HAT configs present"
+          echo "All 16 HAT configs present"


### PR DESCRIPTION
Updates CI workflow to expect 16 HAT configs instead of 15.

PR #97 adds  for EEPROM-less DAC boards.
This commit updates the test so CI passes.