### PR TITLE
fix: display.sh safety and permissions

### DIFF
--- a/common/scripts/display.sh
+++ b/common/scripts/display.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Display detection library — sourced by firstboot.sh, setup.sh, and display-detect.sh
 #
 # Checks whether an HDMI display is physically connected to the Pi.

--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -1316,6 +1316,7 @@ if [[ "$(cd "$COMMON_DIR" 2>/dev/null && pwd)" != "$(cd "$INSTALL_DIR" 2>/dev/nu
     cp "$COMMON_DIR/scripts/display.sh" "$INSTALL_DIR/scripts/"
 fi
 chmod +x "$INSTALL_DIR/scripts/display-detect.sh"
+chmod +x "$INSTALL_DIR/scripts/display.sh"
 if [[ -d /etc/systemd/system ]]; then
     if [[ "$(cd "$COMMON_DIR" 2>/dev/null && pwd)" != "$(cd "$INSTALL_DIR" 2>/dev/null && pwd)" ]]; then
         cp "$COMMON_DIR/systemd/snapclient-display.service" /etc/systemd/system/


### PR DESCRIPTION
## Summary
- Add `set -euo pipefail` to `display.sh` (was the only shell lib without it)
- Add `chmod +x display.sh` in `setup.sh` alongside `display-detect.sh`

From deep council audit (batch 1 quick fixes).

## Test plan
- [ ] shellcheck passes
- [ ] firstboot with display attached works

🤖 Generated with [Claude Code](https://claude.com/claude-code)