### PR TITLE
feat: build snapclient from santcasp fork + IMAGE_TAG variable

### DIFF
--- a/common/.env.example
+++ b/common/.env.example
@@ -1,3 +1,9 @@
+# Docker Image Tag
+# Controls which image version is pulled for all 3 containers.
+# Default: latest (stable release). Set to a dev tag for testing:
+#   IMAGE_TAG=0.4.0-dev.1
+IMAGE_TAG=latest
+
 # Snapserver Configuration
 # Leave empty for mDNS autodiscovery, or set IP/hostname manually.
 # Also used as the metadata server address for fb-display.

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -15,7 +15,7 @@ x-security: &default-security
 
 services:
   snapclient:
-    image: lollonet/snapclient-pi:latest
+    image: lollonet/snapclient-pi:${IMAGE_TAG:-latest}
     container_name: snapclient
     network_mode: host
     restart: unless-stopped
@@ -71,7 +71,7 @@ services:
   # fb-display derives METADATA_HOST from SNAPSERVER_HOST (same server).
 
   audio-visualizer:
-    image: lollonet/snapclient-pi-visualizer:latest
+    image: lollonet/snapclient-pi-visualizer:${IMAGE_TAG:-latest}
     build: ./docker/audio-visualizer
     container_name: audio-visualizer
     profiles:
@@ -117,7 +117,7 @@ services:
           memory: ${VISUALIZER_MEM_RESERVE:-64M}
 
   fb-display:
-    image: lollonet/snapclient-pi-fb-display:latest
+    image: lollonet/snapclient-pi-fb-display:${IMAGE_TAG:-latest}
     build: ./docker/fb-display
     container_name: fb-display
     restart: unless-stopped

--- a/common/docker/snapclient/Dockerfile
+++ b/common/docker/snapclient/Dockerfile
@@ -18,10 +18,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Clone and build snapclient from snapcast (or santcasp fork)
-# Repo and branch are configurable via build args
+# Repo and branch are configurable via build args.
+# Note: with SNAPCAST_BRANCH=develop (constant), Docker caches the clone
+# layer indefinitely. Use --no-cache or pass a unique SNAPCAST_SHA to
+# force re-clone when the branch has new commits.
 ARG SNAPCAST_REPO=https://github.com/lollonet/santcasp.git
 ARG SNAPCAST_BRANCH=develop
 ARG SNAPCAST_TAG=
+ARG SNAPCAST_SHA=latest
 WORKDIR /build
 RUN echo "snapcast repo: $SNAPCAST_REPO branch: ${SNAPCAST_TAG:-$SNAPCAST_BRANCH}" && \
     git clone --depth 1 --branch "${SNAPCAST_TAG:-$SNAPCAST_BRANCH}" "$SNAPCAST_REPO" snapcast

--- a/common/docker/snapclient/Dockerfile
+++ b/common/docker/snapclient/Dockerfile
@@ -17,12 +17,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone and build snapclient from upstream badaix/snapcast
-# SNAPCAST_TAG busts the Docker cache when new version is released
-ARG SNAPCAST_TAG=v0.35.0
+# Clone and build snapclient from snapcast (or santcasp fork)
+# Repo and branch are configurable via build args
+ARG SNAPCAST_REPO=https://github.com/lollonet/santcasp.git
+ARG SNAPCAST_BRANCH=develop
+ARG SNAPCAST_TAG=
 WORKDIR /build
-RUN echo "snapcast tag: $SNAPCAST_TAG" && \
-    git clone --depth 1 --branch $SNAPCAST_TAG https://github.com/badaix/snapcast.git snapcast
+RUN echo "snapcast repo: $SNAPCAST_REPO branch: ${SNAPCAST_TAG:-$SNAPCAST_BRANCH}" && \
+    git clone --depth 1 --branch "${SNAPCAST_TAG:-$SNAPCAST_BRANCH}" "$SNAPCAST_REPO" snapcast
 
 WORKDIR /build/snapcast
 RUN cmake -S . -B build \


### PR DESCRIPTION
## Summary
Companion to lollonet/snapMULTI#198 — switches client to santcasp fork for IPDV jitter measurement testing.

### Changes
- **Dockerfile**: build snapclient from `lollonet/santcasp` instead of `badaix/snapcast`
  - `SNAPCAST_REPO` and `SNAPCAST_BRANCH` build args (configurable, default: santcasp/develop)
  - `SNAPCAST_TAG` overrides branch if set (for pinning to a release)
- **docker-compose.yml**: all 3 images use `${IMAGE_TAG:-latest}` for dev tag support

### How to test with dev images
```bash
# In .env:
IMAGE_TAG=0.4.0-dev.1

# Or inline:
IMAGE_TAG=0.4.0-dev.1 docker compose pull
IMAGE_TAG=0.4.0-dev.1 docker compose up -d
```

## Test plan
- [ ] Build snapclient image locally from santcasp
- [ ] `IMAGE_TAG=0.4.0-dev.1` pulls correct versioned images
- [ ] Default (no IMAGE_TAG) still pulls `:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)