### PR TITLE
fix: write IMAGE_TAG to client .env (council finding)

### DIFF
--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -1092,6 +1092,8 @@ declare -A env_vars=(
     # Version tag (for display) — prefer VERSION file baked by prepare-sd.sh,
     # fall back to git describe (dev clones), then short SHA, then "dev".
     ["APP_VERSION"]="$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || echo "dev")"
+    # Image tag — passed from firstboot.sh in "both" mode, or from install.conf
+    ["IMAGE_TAG"]="${IMAGE_TAG:-latest}"
 )
 
 for key in "${!env_vars[@]}"; do


### PR DESCRIPTION
## Summary
Companion to lollonet/snapMULTI PR. Writes IMAGE_TAG from environment to client `.env` so docker compose reads it.

Without this, "both" mode installs get server=:dev but client=:latest.

## Test plan
- [ ] IMAGE_TAG=dev in env → written to .env → compose pulls :dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)