### PR TITLE
fix: diagnostic dump on standalone setup.sh failure

### DIFF
--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -1448,7 +1448,11 @@ fi
 # Pull images with retry (network hiccups common on Pi WiFi).
 # Pull 2 services at a time — balances network throughput vs SD I/O.
 _pull_tmp=$(mktemp -d)
-trap 'rm -rf "$_pull_tmp"' EXIT
+_pull_cleanup() {
+    _setup_failure_dump
+    rm -rf "$_pull_tmp" 2>/dev/null || true
+}
+trap _pull_cleanup EXIT
 mapfile -t _pull_services < <(docker compose config --services 2>/dev/null)
 if [[ ${#_pull_services[@]} -eq 0 ]]; then
     stop_progress_animation

--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Diagnostic dump on failure (standalone mode only — firstboot has its own trap)
+_setup_failure_dump() {
+    local rc=$?
+    [[ $rc -eq 0 ]] && return
+    echo ""
+    echo "=== SETUP FAILED (exit: $rc) ==="
+    echo "--- Memory ---"
+    free -m 2>/dev/null || true
+    echo "--- Disk ---"
+    df -h / /opt 2>/dev/null || true
+    echo "--- Docker ---"
+    docker ps -a --format 'table {{.Names}}\t{{.Status}}' 2>/dev/null || true
+    echo "=== END DIAGNOSTIC DUMP ==="
+}
+trap _setup_failure_dump EXIT
+
 # Suppress locale warnings from apt and other tools; avoids stdout pollution
 # in functions called via $() substitution.
 export DEBIAN_FRONTEND=noninteractive
@@ -1507,6 +1523,8 @@ if mountpoint -q /media/root-ro 2>/dev/null; then
     log_progress "Baking Docker images to SD card..."
     BAKE_DIR=$(mktemp -d /tmp/snapclient-bake-XXXXX)
     bake_cleanup() {
+        _setup_failure_dump  # chain diagnostic dump on failure
+        rm -rf "$_pull_tmp" 2>/dev/null || true
         sudo umount "$BAKE_DIR" 2>/dev/null || true
         rmdir "$BAKE_DIR" 2>/dev/null || true
         sudo sync


### PR DESCRIPTION
## Summary
- Add `_setup_failure_dump` EXIT trap to setup.sh — prints memory/disk/docker status on failure
- Chains into `bake_cleanup` on overlayroot systems (also adds `_pull_tmp` cleanup)

## Test plan
- [ ] Run setup.sh with intentional error: verify diagnostic dump appears
- [ ] Overlayroot system: verify bake_cleanup chains diagnostic + temp cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)