### PR TITLE
fix: install hardening — silent pulls, diagnostics, disk check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Test resource profile detection
         run: bash tests/test_resource_profiles.sh
 
+      - name: Test pull hardening
+        run: bash tests/test_pull_hardening.sh
+
       - name: Validate HAT config count
         run: |
           count=$(ls -1 common/audio-hats/*.conf | wc -l)

--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -956,6 +956,7 @@ detect_resource_profile() {
 
     # Fallback to standard profile if detection failed (0 or very low = likely error)
     if (( mem_mb < 256 )); then
+        echo "WARNING: Only ${mem_mb}MB RAM detected — client needs at least 256MB" >&2
         echo "standard"
         return
     fi
@@ -1053,36 +1054,23 @@ esac
 
 cd "$INSTALL_DIR"
 
-# Read current snapserver from .env if exists (empty = autodiscovery)
+# Snapserver host: empty = autodiscovery via mDNS at boot.
+# discover-server.sh (systemd ExecStartPre) handles boot-time mDNS lookup
+# and writes the IP to .env. We don't bake an IP at install time because
+# the server's address can change between installs and reboots.
+# "Both" mode (server+client on same Pi) uses 127.0.0.1 — set by firstboot.sh.
 current_snapserver=$(grep "^SNAPSERVER_HOST=" "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 || echo "")
 
 if [ "$AUTO_MODE" = true ]; then
-    snapserver_ip="${SNAPSERVER_HOST:-$current_snapserver}"
-    echo "Snapserver: ${snapserver_ip:-autodiscovery (mDNS)}"
+    # In auto mode, only use explicit env var (e.g. SNAPSERVER_HOST=127.0.0.1 for "both" mode)
+    # Empty means autodiscovery — don't bake install-time mDNS results
+    snapserver_ip="${SNAPSERVER_HOST:-}"
+    echo "Snapserver: ${snapserver_ip:-autodiscovery (mDNS at boot)}"
 else
     [ -z "$current_snapserver" ] && echo "Current: mDNS autodiscovery" || echo "Current Snapserver: $current_snapserver"
     # Configure snapserver host (empty = autodiscovery via mDNS)
     read -rp "Enter Snapserver IP/hostname (or press Enter for autodiscovery): " snapserver_ip
     snapserver_ip=${snapserver_ip:-$current_snapserver}
-fi
-
-# Resolve snapserver IP via mDNS when display is active and no explicit IP set.
-# Snapclient handles empty SNAPSERVER_HOST via built-in mDNS, but fb-display
-# connects directly via WebSocket and needs an explicit IP/hostname.
-# docker-compose.yml maps METADATA_HOST from SNAPSERVER_HOST.
-if [[ -z "$snapserver_ip" ]]; then
-    echo "Discovering snapserver via mDNS for display metadata..."
-    if command -v avahi-browse &>/dev/null; then
-        snapserver_ip=$(timeout 10 avahi-browse -rpt _snapcast._tcp 2>/dev/null \
-            | awk -F';' '/^=/ && $3=="IPv4" {print $8; exit}') || true
-    fi
-    if [[ -n "$snapserver_ip" ]]; then
-        echo "Discovered snapserver at: $snapserver_ip"
-    else
-        echo "WARNING: Could not discover snapserver via mDNS."
-        echo "  Display metadata will fall back to localhost."
-        echo "  Set SNAPSERVER_HOST in .env if server is on another host."
-    fi
 fi
 
 # Always use "default" ALSA device — asound.conf routes it to either:
@@ -1110,10 +1098,9 @@ update_env_var() {
     fi
 }
 
-# Only update SNAPSERVER_HOST if we have a value (don't clear existing on failed discovery)
-if [[ -n "$snapserver_ip" ]]; then
-    update_env_var "SNAPSERVER_HOST" "$snapserver_ip"
-fi
+# Write SNAPSERVER_HOST: explicit IP for "both" mode, empty for autodiscovery.
+# discover-server.sh updates this at boot via mDNS.
+update_env_var "SNAPSERVER_HOST" "${snapserver_ip:-}"
 
 # Update all environment variables
 declare -A env_vars=(
@@ -1433,8 +1420,19 @@ start_progress_animation 10 60 40  # Animate during long image pull
 
 cd "$INSTALL_DIR"
 
+# Pre-flight: ensure enough disk space for images (~1 GB needed)
+_avail_mb=$(df -BM --output=avail "$INSTALL_DIR" 2>/dev/null | tail -1 | tr -d ' M')
+if [[ -n "$_avail_mb" ]] && [[ "$_avail_mb" -lt 1024 ]]; then
+    stop_progress_animation
+    echo "ERROR: Only ${_avail_mb}MB free — need at least 1 GB for container images"
+    echo "  Free up space and re-run: docker compose pull"
+    exit 1
+fi
+
 # Pull images with retry (network hiccups common on Pi WiFi).
 # Pull 2 services at a time — balances network throughput vs SD I/O.
+_pull_tmp=$(mktemp -d)
+trap 'rm -rf "$_pull_tmp"' EXIT
 mapfile -t _pull_services < <(docker compose config --services 2>/dev/null)
 if [[ ${#_pull_services[@]} -eq 0 ]]; then
     stop_progress_animation
@@ -1444,16 +1442,22 @@ fi
 
 _pull_failed=()
 
-# Pull a single service with 3-attempt retry. Returns 0 on success.
+# Pull a single service with 3-attempt retry.
+# Output is suppressed on success and surfaced on failure.
 _pull_one() {
     local svc="$1"
+    local log="$_pull_tmp/pull-$svc"
     local delays=(0 10 30)  # retry after 10s, 30s
     for i in 0 1 2; do
         [[ ${delays[$i]} -gt 0 ]] && { log_progress "Retrying $svc in ${delays[$i]}s..."; sleep "${delays[$i]}"; }
-        if docker compose pull "$svc" 2>&1 | tail -3; then
+        if docker compose pull "$svc" >"$log" 2>&1; then
+            rm -f "$log"
             return 0
         fi
     done
+    # Surface last attempt's output on failure
+    tail -5 "$log"
+    rm -f "$log"
     return 1
 }
 
@@ -1462,25 +1466,25 @@ for ((i=0; i<${#_pull_services[@]}; i+=2)); do
     svc1="${_pull_services[$i]}"
     svc2="${_pull_services[$i+1]:-}"
 
-    # Pull svc2 in background (output to temp file to avoid interleaving)
+    # Pull svc2 in background (capture retry messages to avoid interleaving)
     _bg_pid="" _bg_log=""
     if [[ -n "$svc2" ]]; then
         log_progress "Pulling $svc2..."
-        _bg_log=$(mktemp)
+        _bg_log="$_pull_tmp/bg-$svc2"
         _pull_one "$svc2" >"$_bg_log" 2>&1 &
         _bg_pid=$!
     fi
 
-    # svc1 with 3 attempts in foreground
+    # svc1 in foreground
     log_progress "Pulling $svc1..."
     if ! _pull_one "$svc1"; then
         _pull_failed+=("$svc1")
     fi
 
-    # Wait for background svc2 (already retried 3x in background)
+    # Wait for background svc2
     if [[ -n "$_bg_pid" ]]; then
         if ! wait "$_bg_pid" 2>/dev/null; then
-            cat "$_bg_log"  # surface output on failure
+            cat "$_bg_log"  # surface failure output
             _pull_failed+=("$svc2")
         fi
         rm -f "$_bg_log"
@@ -1496,6 +1500,7 @@ if [[ ${#_pull_failed[@]} -gt 0 ]]; then
     exit 1
 fi
 log_progress "All images pulled successfully"
+docker image prune -f >/dev/null 2>&1 || true
 echo ""
 
 # ============================================
@@ -1507,6 +1512,7 @@ if mountpoint -q /media/root-ro 2>/dev/null; then
     log_progress "Baking Docker images to SD card..."
     BAKE_DIR=$(mktemp -d /tmp/snapclient-bake-XXXXX)
     bake_cleanup() {
+        rm -rf "$_pull_tmp" 2>/dev/null || true
         sudo umount "$BAKE_DIR" 2>/dev/null || true
         rmdir "$BAKE_DIR" 2>/dev/null || true
         sudo sync
@@ -1559,8 +1565,9 @@ fi
 # ============================================
 progress_complete
 
+_elapsed="$((SECONDS / 60))m$((SECONDS % 60))s"
 echo "========================================="
-echo "Setup Complete!"
+echo "Setup Complete! ($_elapsed)"
 echo "========================================="
 echo ""
 echo "Configuration Summary:"

--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 _setup_failure_dump() {
     local rc=$?
     [[ $rc -eq 0 ]] && return
+    stop_progress_animation 2>/dev/null || true
     echo ""
     echo "=== SETUP FAILED (exit: $rc) ==="
     echo "--- Memory ---"

--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -1576,7 +1576,7 @@ if mountpoint -q /media/root-ro 2>/dev/null; then
         exit 1
     fi
 
-    sudo sync
+    # sync happens in bake_cleanup EXIT trap
     log_progress "Docker images baked to SD card"
 else
     echo "Non-overlayroot system -- Docker images stored directly on disk"

--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Diagnostic dump on failure (standalone mode only — firstboot has its own trap)
+_setup_failure_dump() {
+    local rc=$?
+    [[ $rc -eq 0 ]] && return
+    echo ""
+    echo "=== SETUP FAILED (exit: $rc) ==="
+    echo "--- Memory ---"
+    free -m 2>/dev/null || true
+    echo "--- Disk ---"
+    df -h / /opt 2>/dev/null || true
+    echo "--- Docker ---"
+    docker ps -a --format 'table {{.Names}}\t{{.Status}}' 2>/dev/null || true
+    echo "=== END DIAGNOSTIC DUMP ==="
+}
+trap _setup_failure_dump EXIT
+
 # Suppress locale warnings from apt and other tools; avoids stdout pollution
 # in functions called via $() substitution.
 export DEBIAN_FRONTEND=noninteractive
@@ -1432,7 +1448,11 @@ fi
 # Pull images with retry (network hiccups common on Pi WiFi).
 # Pull 2 services at a time — balances network throughput vs SD I/O.
 _pull_tmp=$(mktemp -d)
-trap 'rm -rf "$_pull_tmp"' EXIT
+_pull_cleanup() {
+    _setup_failure_dump
+    rm -rf "$_pull_tmp" 2>/dev/null || true
+}
+trap _pull_cleanup EXIT
 mapfile -t _pull_services < <(docker compose config --services 2>/dev/null)
 if [[ ${#_pull_services[@]} -eq 0 ]]; then
     stop_progress_animation
@@ -1512,6 +1532,7 @@ if mountpoint -q /media/root-ro 2>/dev/null; then
     log_progress "Baking Docker images to SD card..."
     BAKE_DIR=$(mktemp -d /tmp/snapclient-bake-XXXXX)
     bake_cleanup() {
+        _setup_failure_dump  # chain diagnostic dump on failure
         rm -rf "$_pull_tmp" 2>/dev/null || true
         sudo umount "$BAKE_DIR" 2>/dev/null || true
         rmdir "$BAKE_DIR" 2>/dev/null || true

--- a/tests/test_pull_hardening.sh
+++ b/tests/test_pull_hardening.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Test install hardening: disk space check and _pull_one retry logic.
+# Uses mocks for docker compose and df to test without real Docker.
+
+pass=0
+fail=0
+
+assert_eq() {
+    local actual="$1" expected="$2" desc="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $desc (got '$actual', expected '$expected')"
+        fail=$((fail + 1))
+    fi
+}
+
+# ── Disk space check ──────────────────────────────────────────────
+
+echo "Testing disk space pre-flight check..."
+
+# Simulate df -BM --output=avail output and test the parsing + threshold
+test_disk_check() {
+    local avail_mb="$1" should_fail="$2" desc="$3"
+
+    # The logic from setup.sh:
+    #   _avail_mb=$(df -BM --output=avail "$INSTALL_DIR" 2>/dev/null | tail -1 | tr -d ' M')
+    #   if [[ -n "$_avail_mb" ]] && [[ "$_avail_mb" -lt 1024 ]]; then exit 1; fi
+    local _avail_mb="$avail_mb"
+    local result="pass"
+    if [[ -n "$_avail_mb" ]] && [[ "$_avail_mb" -lt 1024 ]]; then
+        result="fail"
+    fi
+
+    assert_eq "$result" "$should_fail" "$desc"
+}
+
+test_disk_check "500"  "fail" "500MB free -> should fail"
+test_disk_check "1023" "fail" "1023MB free -> should fail"
+test_disk_check "1024" "pass" "1024MB free -> should pass"
+test_disk_check "2048" "pass" "2048MB free -> should pass"
+test_disk_check ""     "pass" "empty (df failed) -> fail-open"
+
+# Test df output parsing (the actual df -BM output format)
+echo ""
+echo "Testing df output parsing..."
+
+test_df_parse() {
+    local df_output="$1" expected="$2" desc="$3"
+
+    local parsed
+    parsed=$(echo "$df_output" | tail -1 | tr -d ' M')
+
+    assert_eq "$parsed" "$expected" "$desc"
+}
+
+test_df_parse "  Avail
+  2048M" "2048" "Standard df -BM output"
+test_df_parse "  Avail
+    512M" "512" "Padded df output"
+test_df_parse "  Avail
+ 22016M" "22016" "Large disk"
+
+# ── _pull_one retry logic ─────────────────────────────────────────
+
+echo ""
+echo "Testing _pull_one retry logic..."
+
+# Create a temp dir for the test
+_test_tmp=$(mktemp -d)
+trap 'rm -rf "$_test_tmp"' EXIT
+
+# Mock docker compose pull: reads a counter file and fails N times
+_mock_pull_counter="$_test_tmp/pull-counter"
+
+# Mock log_progress (no-op in tests)
+log_progress() { :; }
+
+# Recreate _pull_one with mocked docker compose
+_pull_one_mock() {
+    local svc="$1"
+    local log="$_test_tmp/pull-$svc"
+    local delays=(0 0 0)  # no actual sleep in tests
+    for i in 0 1 2; do
+        [[ ${delays[$i]} -gt 0 ]] && sleep "${delays[$i]}"
+        # Mock: read counter, decrement, fail if > 0
+        local count
+        count=$(cat "$_mock_pull_counter" 2>/dev/null || echo 0)
+        if [[ "$count" -le 0 ]]; then
+            echo "pull succeeded" >"$log"
+            rm -f "$log"
+            return 0
+        fi
+        echo "pull failed (attempt)" >"$log"
+        echo $((count - 1)) > "$_mock_pull_counter"
+    done
+    tail -5 "$log" 2>/dev/null
+    rm -f "$log"
+    return 1
+}
+
+# Test: succeed on first attempt
+echo "0" > "$_mock_pull_counter"
+if _pull_one_mock "test-svc"; then
+    assert_eq "ok" "ok" "Succeed on first attempt"
+else
+    assert_eq "fail" "ok" "Succeed on first attempt"
+fi
+
+# Test: fail once, succeed on retry
+echo "1" > "$_mock_pull_counter"
+if _pull_one_mock "test-svc"; then
+    assert_eq "ok" "ok" "Fail once, succeed on second attempt"
+else
+    assert_eq "fail" "ok" "Fail once, succeed on second attempt"
+fi
+
+# Test: fail twice, succeed on third
+echo "2" > "$_mock_pull_counter"
+if _pull_one_mock "test-svc"; then
+    assert_eq "ok" "ok" "Fail twice, succeed on third attempt"
+else
+    assert_eq "fail" "ok" "Fail twice, succeed on third attempt"
+fi
+
+# Test: fail all 3 attempts
+echo "99" > "$_mock_pull_counter"
+if _pull_one_mock "test-svc"; then
+    assert_eq "ok" "fail" "Fail all 3 attempts -> should return 1"
+else
+    assert_eq "fail" "fail" "Fail all 3 attempts -> should return 1"
+fi
+
+# Test: temp files cleaned up on success
+echo "0" > "$_mock_pull_counter"
+_pull_one_mock "cleanup-test" >/dev/null 2>&1
+if [[ ! -f "$_test_tmp/pull-cleanup-test" ]]; then
+    assert_eq "ok" "ok" "Temp file removed on success"
+else
+    assert_eq "leaked" "ok" "Temp file removed on success"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED: $fail tests failed, $pass passed"
+    exit 1
+fi
+echo "All $pass tests passed!"


### PR DESCRIPTION
## Summary
Cherry-pick of install hardening from develop (#144, #145) to main:
- Silent docker pulls (suppress output on success, surface on failure)
- Disk space pre-flight check (1 GB minimum)
- Temp file cleanup with trap
- Docker image prune after pull
- Install duration logging
- Diagnostic dump on failure (memory/disk/docker status)
- Proper trap chaining (diagnostic → pull cleanup → bake cleanup)
- Don't bake snapserver IP at install time (use boot-time mDNS)
- RAM warning for <256MB systems

## Test plan
- [ ] Fresh install on Pi: verify clean log output
- [ ] Failure scenario: verify diagnostic dump appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)