### PR TITLE
fix: restore badaix/snapcast on main (santcasp leaked via PR #143)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,12 +31,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Get latest santcasp commit SHA
-        id: santcasp
+      - name: Get latest snapcast commit SHA (cache buster)
+        id: snapcast
         run: |
-          SHA=$(git ls-remote https://github.com/lollonet/santcasp.git HEAD | cut -f1)
+          SHA=$(git ls-remote https://github.com/badaix/snapcast.git HEAD | cut -f1)
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "santcasp HEAD: $SHA"
+          echo "snapcast HEAD: $SHA"
 
       - name: Extract metadata
         id: meta
@@ -60,7 +60,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: SANTCASP_SHA=${{ steps.santcasp.outputs.sha }}
+          build-args: SNAPCAST_SHA=${{ steps.snapcast.outputs.sha }}
 
       - name: Scan image with Trivy
         id: trivy-snapclient

--- a/common/docker/snapclient/Dockerfile
+++ b/common/docker/snapclient/Dockerfile
@@ -17,13 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone and build snapclient from snapcast (or santcasp fork)
-# Repo and branch are configurable via build args.
-# Note: with SNAPCAST_BRANCH=develop (constant), Docker caches the clone
-# layer indefinitely. Use --no-cache or pass a unique SNAPCAST_SHA to
-# force re-clone when the branch has new commits.
-ARG SNAPCAST_REPO=https://github.com/lollonet/santcasp.git
-ARG SNAPCAST_BRANCH=develop
+# Clone and build snapclient from upstream badaix/snapcast.
+# Repo and tag are configurable via build args.
+# develop branch overrides SNAPCAST_REPO to lollonet/santcasp fork.
+ARG SNAPCAST_REPO=https://github.com/badaix/snapcast.git
+ARG SNAPCAST_BRANCH=master
 ARG SNAPCAST_TAG=
 ARG SNAPCAST_SHA=latest
 WORKDIR /build

--- a/common/docker/snapclient/Dockerfile
+++ b/common/docker/snapclient/Dockerfile
@@ -19,13 +19,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Clone and build snapclient from upstream badaix/snapcast.
 # Repo and tag are configurable via build args.
-# develop branch overrides SNAPCAST_REPO to lollonet/santcasp fork.
+# CI passes SNAPCAST_REPO=...santcasp.git when building the develop branch.
 ARG SNAPCAST_REPO=https://github.com/badaix/snapcast.git
 ARG SNAPCAST_BRANCH=master
 ARG SNAPCAST_TAG=
 ARG SNAPCAST_SHA=latest
 WORKDIR /build
-RUN echo "snapcast repo: $SNAPCAST_REPO branch: ${SNAPCAST_TAG:-$SNAPCAST_BRANCH}" && \
+RUN echo "snapcast repo: $SNAPCAST_REPO branch: ${SNAPCAST_TAG:-$SNAPCAST_BRANCH} sha: $SNAPCAST_SHA" && \
     git clone --depth 1 --branch "${SNAPCAST_TAG:-$SNAPCAST_BRANCH}" "$SNAPCAST_REPO" snapcast
 
 WORKDIR /build/snapcast


### PR DESCRIPTION
## Summary
PR #143 accidentally cherry-picked the santcasp fork switch from develop into main. This restores the correct state:

- **main** → `badaix/snapcast` (upstream, vanilla)
- **develop** → `lollonet/santcasp` (fork with extra features)

Changes:
- `Dockerfile`: `SNAPCAST_REPO` → `badaix/snapcast.git`, branch → `master`
- `docker-build.yml`: cache buster fetches `badaix/snapcast` SHA

After merge: reset develop onto main, add santcasp commit → develop is 1 commit ahead (clean).

## Test plan
- [ ] CI builds Dockerfile with badaix/snapcast successfully
- [ ] `:latest` tag on Docker Hub uses upstream snapcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)