### PR TITLE
feat: single-branch CI — santcasp via workflow_dispatch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,8 +38,10 @@ jobs:
 
       - name: Determine snapcast source
         id: snapcast
+        env:
+          USE_SANTCASP: ${{ inputs.use_santcasp }}
         run: |
-          if [[ "${{ inputs.use_santcasp }}" == "true" ]]; then
+          if [[ "$USE_SANTCASP" == "true" ]]; then
             REPO="https://github.com/lollonet/santcasp.git"
           else
             REPO="https://github.com/badaix/snapcast.git"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,10 +43,12 @@ jobs:
         run: |
           if [[ "$USE_SANTCASP" == "true" ]]; then
             REPO="https://github.com/lollonet/santcasp.git"
+            BRANCH="develop"
           else
             REPO="https://github.com/badaix/snapcast.git"
+            BRANCH="master"
           fi
-          SHA=$(git ls-remote "$REPO" HEAD | cut -f1)
+          SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH" | cut -f1)
           echo "repo=$REPO" >> "$GITHUB_OUTPUT"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "snapcast: $REPO SHA: $SHA"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,8 +3,13 @@ name: Docker Build
 on:
   push:
     tags: ['v*']
-    branches: [develop]
   workflow_dispatch:
+    inputs:
+      use_santcasp:
+        description: 'Build :dev images from santcasp fork'
+        required: false
+        type: boolean
+        default: false
 
 env:
   IMAGE_NAME: lollonet/snapclient-pi
@@ -31,12 +36,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Get latest snapcast commit SHA (cache buster)
+      - name: Determine snapcast source
         id: snapcast
         run: |
-          SHA=$(git ls-remote https://github.com/badaix/snapcast.git HEAD | cut -f1)
+          if [[ "${{ inputs.use_santcasp }}" == "true" ]]; then
+            REPO="https://github.com/lollonet/santcasp.git"
+          else
+            REPO="https://github.com/badaix/snapcast.git"
+          fi
+          SHA=$(git ls-remote "$REPO" HEAD | cut -f1)
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "snapcast HEAD: $SHA"
+          echo "snapcast: $REPO SHA: $SHA"
 
       - name: Extract metadata
         id: meta
@@ -50,7 +61,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=raw,value=dev,enable=${{ inputs.use_santcasp == true }}
 
       - name: Build and push
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -60,12 +71,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: SNAPCAST_SHA=${{ steps.snapcast.outputs.sha }}
+          build-args: |
+            SNAPCAST_REPO=${{ steps.snapcast.outputs.repo }}
+            SNAPCAST_SHA=${{ steps.snapcast.outputs.sha }}
 
       - name: Scan image with Trivy
         id: trivy-snapclient
-        continue-on-error: true  # Trivy is reporting only — network failures must not block deploy
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 # v0.35.0
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: sarif
@@ -112,7 +125,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=raw,value=dev,enable=${{ inputs.use_santcasp == true }}
 
       - name: Build and push
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -125,8 +138,8 @@ jobs:
 
       - name: Scan image with Trivy
         id: trivy-visualizer
-        continue-on-error: true  # Trivy is reporting only — network failures must not block deploy
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 # v0.35.0
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: sarif
@@ -173,7 +186,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=raw,value=dev,enable=${{ inputs.use_santcasp == true }}
 
       - name: Build and push
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -186,8 +199,8 @@ jobs:
 
       - name: Scan image with Trivy
         id: trivy-fb-display
-        continue-on-error: true  # Trivy is reporting only — network failures must not block deploy
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 # v0.35.0
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: sarif

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,7 +60,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && inputs.use_santcasp != true }}
             type=raw,value=dev,enable=${{ inputs.use_santcasp == true }}
 
       - name: Build and push
@@ -124,7 +124,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && inputs.use_santcasp != true }}
             type=raw,value=dev,enable=${{ inputs.use_santcasp == true }}
 
       - name: Build and push
@@ -185,7 +185,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && inputs.use_santcasp != true }}
             type=raw,value=dev,enable=${{ inputs.use_santcasp == true }}
 
       - name: Build and push

--- a/common/docker/snapclient/Dockerfile
+++ b/common/docker/snapclient/Dockerfile
@@ -17,9 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone and build snapclient from upstream badaix/snapcast.
-# Repo and tag are configurable via build args.
-# CI passes SNAPCAST_REPO=...santcasp.git when building the develop branch.
+# Clone and build snapclient from upstream badaix/snapcast (default).
+# CI passes SNAPCAST_REPO=santcasp via workflow_dispatch for :dev builds.
 ARG SNAPCAST_REPO=https://github.com/badaix/snapcast.git
 ARG SNAPCAST_BRANCH=master
 ARG SNAPCAST_TAG=

--- a/common/docker/snapclient/Dockerfile
+++ b/common/docker/snapclient/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Clone and build snapclient from upstream badaix/snapcast (default).
-# CI passes SNAPCAST_REPO=santcasp via workflow_dispatch for :dev builds.
+# CI passes SNAPCAST_REPO=lollonet/santcasp.git via workflow_dispatch for :dev builds.
 ARG SNAPCAST_REPO=https://github.com/badaix/snapcast.git
 ARG SNAPCAST_BRANCH=master
 ARG SNAPCAST_TAG=


### PR DESCRIPTION
## Summary
Eliminates the develop branch. `:dev` images (santcasp) are now built on-demand via `workflow_dispatch` with `use_santcasp` checkbox. Tag push builds `:latest` from badaix (Dockerfile default).

- `docker-build.yml`: replace `branches: [develop]` trigger with `workflow_dispatch` input
- Dockerfile: badaix default, CI passes `SNAPCAST_REPO` build-arg for santcasp
- All 3 images (snapclient, visualizer, fb-display) get `:dev` tag when santcasp selected

After merge: delete develop branch.

## Test plan
- [ ] Tag push: verify `:latest` built from badaix
- [ ] workflow_dispatch with santcasp: verify `:dev` built from santcasp
- [ ] workflow_dispatch without santcasp: verify `:manual` built from badaix

🤖 Generated with [Claude Code](https://claude.com/claude-code)